### PR TITLE
add user and password to amqp url if set in .env file

### DIFF
--- a/backend/lost/logic/config.py
+++ b/backend/lost/logic/config.py
@@ -43,6 +43,12 @@ class LOSTConfig(object):
         self.rabbitmq_ip = "rabbitmqlost"
         if "RABBITMQ_IP" in os.environ:
             self.rabbitmq_ip = os.environ['RABBITMQ_IP']
+        self.rabbitmq_user = None
+        if "RABBITMQ_USER" in os.environ:
+            self.rabbitmq_user = os.environ['RABBITMQ_USER']
+        self.rabbitmq_password = None
+        if "RABBITMQ_PASSWORD" in os.environ:
+            self.rabbitmq_password = os.environ['RABBITMQ_PASSWORD']
 
         self.send_mail = False
         self.mail_server = ""

--- a/backend/lost/settings.py
+++ b/backend/lost/settings.py
@@ -34,5 +34,16 @@ CORS_HEADERS = 'Content-Type'
 
 DATA_URL = 'data/'
 
-CELERY_BROKER_URL = 'amqp://'+LOST_CONFIG.rabbitmq_ip+':'+LOST_CONFIG.rabbitmq_port
-CELERY_RESULT_BACKEND = 'amqp://'+LOST_CONFIG.rabbitmq_ip+':'+LOST_CONFIG.rabbitmq_port
+url = 'amqp://'
+
+# Allow username/password protected connexion
+if LOST_CONFIG.rabbitmq_user is not None:
+    if LOST_CONFIG.rabbitmq_password is not None:
+        url += LOST_CONFIG.rabbitmq_user + ":" + LOST_CONFIG.rabbitmq_password
+    else:
+        url += LOST_CONFIG.rabbitmq_user
+    url += "@"
+url += LOST_CONFIG.rabbitmq_ip + ':' + LOST_CONFIG.rabbitmq_port
+
+CELERY_BROKER_URL = url
+CELERY_RESULT_BACKEND = url

--- a/docker/compose/.env
+++ b/docker/compose/.env
@@ -32,6 +32,8 @@ WORKER_BEAT=10
 
 #RABBITMQ_IP=rabbitmqlost
 #RABBITMQ_PORT=5672
+#RABBITMQ_USER=guest
+#RABBITMQ_PASSWORD=password
 
 # Mail Settings. Comment out if you don't want to use emails.
 #MAIL_SERVER=yourserver.com


### PR DESCRIPTION
# Configuration for a password protected Rabbitmq
Added configuration for rabbitmq protected by a user:password combo.

## Description
* Added two new environment variables to the `.env` file (commented by default) : 
```yaml
RABBITMQ_USER=guest
RABBITMQ_PASSWORD=password
```
* Modified the `config.py` to go with the new env variables where I set them to None if commented in the .env file.
* Finaly the I modified the `settings.py` to create a custom `amqp://` url working with user and password combo, user only or, like before, without any of them.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Related Issue
Issue 133 : https://github.com/l3p-cv/lost/issues/133 

## Motivation and Context
Allows me to connect to a rabbitmq protected by a user password combo.

## How Has This Been Tested?
Tried it on my cluster and locally with docker-compose.

## Screenshots (if appropriate):
Nothing to add.