### PR TITLE
skip creating mamba env when using docker

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -22,11 +22,14 @@ echo -e ' \t ' 🔍🔍🔍🔍🔍🔍🔍🔍🔍🔍🔍🔍
 echo
 echo 🛠️  installing backend dependencies
 
-# create mamba env named lost with all needed dependencies
-$LOST_MAMBA_BASE_DIR/bin/mamba create -n lost adlfs bokeh dask distributed \
-    flask==1.1.2 flask-jwt-extended==3.13.1 flask-cors flask-ldap3-login flask-mail flask-restx flask-sqlalchemy flask-user flask-wtf jupyterlab \
-    fsspec imagesize mysqlclient numpy opencv pandas pyjwt=1.7.1 pytest python python-devtools python-igraph sphinx sk-video sqlalchemy scikit-image \
-    uwsgi nodejs==14.17.1 $LOST_MAMBA_ADDITIONAL_PACKAGES
+# mamba env is created in lost-base when using docker 
+if [ -z ${IS_USING_DOCKER+x} ] || [ "$IS_USING_DOCKER" != "true" ]; then
+    # create mamba env named lost with all needed dependencies
+    $LOST_MAMBA_BASE_DIR/bin/mamba create -n lost adlfs bokeh dask distributed \
+        flask==1.1.2 flask-jwt-extended==3.13.1 flask-cors flask-ldap3-login flask-mail flask-restx flask-sqlalchemy flask-user flask-wtf jupyterlab \
+        fsspec imagesize mysqlclient numpy opencv pandas pyjwt=1.7.1 pytest python python-devtools python-igraph sphinx sk-video sqlalchemy scikit-image \
+        uwsgi nodejs==14.17.1 $LOST_MAMBA_ADDITIONAL_PACKAGES
+fi
 
 # make conda available inside bash shell scripts
 eval "$($LOST_MAMBA_BASE_DIR/bin/conda shell.bash hook)"


### PR DESCRIPTION
# My Title
Fix #152 

## Description
Skip creating mamba env when using docker because it is already built in lost-base

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] I have read the **CONTRIBUTING** document.
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/l3p-cv/lost/issues/152

## Screenshots (if appropriate):
