### PR TITLE
added option to use the lost-test image

### DIFF
--- a/docker/quick_setup/quick_setup.py
+++ b/docker/quick_setup/quick_setup.py
@@ -29,7 +29,7 @@ class DockerComposeBuilder(object):
     def get_lost(self):
         return (
             '    lost:\n'
-            '      image: l3pcv/lost:${LOST_VERSION}\n'
+            '      image: l3pcv/lost' + self.dockerImageSlug + ':${LOST_VERSION}\n'
             '      container_name: lost\n'
             '      command: bash /entrypoint.sh\n'
             '      env_file:\n'
@@ -85,9 +85,14 @@ class QuickSetup(object):
             # self.release = lost.__version__
         else:
             self.release = args.release
+        if args.testing == "True":
+            self.dockerImageSlug = '-test'
+        else:
+            self.dockerImageSlug = ''
     
     def write_docker_compose(self, store_path):
         builder = DockerComposeBuilder()
+        builder.dockerImageSlug = self.dockerImageSlug
         builder.write_production_file(store_path)
         logging.info('Wrote docker-compose config to: {}'.format(store_path))
         
@@ -189,6 +194,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Quick setup for lost on linux')
     parser.add_argument('install_path', help='Specify path to install lost.')
     parser.add_argument('--release', help='LOST release you want to install.', default=None)
+    parser.add_argument('--testing', help='use the LOST images from testing stage.', default=None)
     parser.add_argument('-noai', '--no_ai', help='Do not add ai examples and no lost-cv worker', action='store_true')
     args = parser.parse_args()
     qs = QuickSetup(args)


### PR DESCRIPTION
# Added option to use the lost-test docker image
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When using quick_setup.py the `lost-test` image can be used (instead of `lost`) for accessing images from testing stage.  
Use the `--testing True` argument to create the LOST environment with the `lost-test`-image.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] I have read the **CONTRIBUTING** document.
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
