### PR TITLE
Added phpmyadmin to quick_setup.py. Phpmyadmin can be set via argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ You are welcome to test the current version anyway:
     cd lost/docker/quick_setup/
     python3 quick_setup.py /path/to/install/lost --release 2.0.0-alpha.2
     ```
+    If you want to use phpmyadmin, you can set it via argument
+    ```
+    python3 quick_setup.py /path/to/install/lost --release 2.0.0-alpha.2 --phpmyadmin
+    ```
+
 5. Run LOST:
 
     Follow instructions of the quick_setup script, 

--- a/docker/compose/.env
+++ b/docker/compose/.env
@@ -6,6 +6,7 @@ LOST_VERSION=lost-version
 
 # LOST Port binding to host machine
 LOST_FRONTEND_PORT=80
+PHP_MYADMIN_PORT=8081
 
 # LOST app directory
 LOST_APP=/home/lost/app


### PR DESCRIPTION
# Added phpmyadmin to quick_setup.py
Added phpmyadmin to quick_setup.py. Phpmyadmin can be set via argument

## Description
Phpmyadmin can be optionally added to generated docker-compose file

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## How Has This Been Tested?
- Generate docker-compose file without phpmyadmin
- Generate docker-compose file with phpyadmin
- Check if all containers are running correctly