### PR TITLE
allow lost-sia to be used with react 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added an InfoBox (AnnoStats) that shows the number of annotation per label in an image
     - This box allows also to hide annotations of a specific label
     - See #86, #160 and #161
+  - Added Support for react 17 and 18 for the lost-sia npm package
 - MIA:
   - Show labels as tags
   - Allow to zoom into images in an extra modal

--- a/frontend/lost/src/containers/Annotation/SIA/lost-sia/package.json
+++ b/frontend/lost/src/containers/Annotation/SIA/lost-sia/package.json
@@ -22,7 +22,7 @@
   "peerDependencies": {
     "prop-types": "^15.5.4",
     "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
     "lodash": "^4.17.15",
     "semantic-ui-react": "^2.0.3"
   },


### PR DESCRIPTION
# Support for React 18
Changed the allowed react versions for the lost-sia npm package to allow the project to be used with react 17 and 18.

## Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] CHANGELOG was updated
  - Please add your changes in the **unreleased section** 
  - Add a note if your changes apply to an **older version** of this software 
- [x] The destination branch has been merged into my branch before I created this merge request
- [ ] All interfaces to the outside world have been documented
  - For Python use [google doc style](https://google.github.io/styleguide/pyguide.html) -> [examples here](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Changes have been tested in the destination environment
- [ ] Unit tests have been written
- [x ] I did not test anything BECAUSE: The package has to be built first
- [ ] Nothing from above, I tested this way:

## Screenshots (if appropriate):
