### PR TITLE
fix spinner blocking other elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased] - 
 ### Added
 - Your stuff here
+### Fixed
+- Removed centered spinner of CoreDataTable, when faced with empty data, to not block the rest of the page
 
 ## [2.7.0] - 2025-06-12 
 ### Added

--- a/frontend/lost/src/components/CoreDataTable.jsx
+++ b/frontend/lost/src/components/CoreDataTable.jsx
@@ -143,24 +143,6 @@ function CoreDataTable({
                     ))}
                 </CTableBody>
             </CTable>
-            {tableData.length === 0 && (
-                <div
-                    style={{
-                        position: 'absolute',
-                        top: 0,
-                        left: 0,
-                        zIndex: 10,
-                        width: '100%',
-                        height: '100%',
-                        background: 'rgba(255,255,255,0.6)',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                    }}
-                >
-                    <CSpinner />
-                </div>
-            )}
             <PaginationWrapper table={table}
                 visible={usePagination}
                 wholeData={wholeData}


### PR DESCRIPTION
# Fix empty tables blocking a whole page with a spinner
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] CHANGELOG was updated
  - Please add your changes in the **unreleased section** 
  - Add a note if your changes apply to an **older version** of this software 
- [X] The destination branch has been merged into my branch before I created this merge request
- [X] All interfaces to the outside world have been documented
  - For Python use [google doc style](https://google.github.io/styleguide/pyguide.html) -> [examples here](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Changes have been tested in the destination environment
- [ ] Unit tests have been written
- [ ] I did not test anything BECAUSE: 
- [X] Nothing from above, I tested this way: Tested locally and also with forced values given to the changed component, to provoke misbehavior

## Screenshots (if appropriate):
